### PR TITLE
Update workflow to use GH CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,6 @@ jobs:
       - build-and-deploy-arm
     steps:
       - name: Update Downstream
-        uses: benc-uk/workflow-dispatch@v1
-        with: 
-          ref:      refs/heads/master
-          workflow: ci
-          repo:     awharn-docker/jenkins-nvm-zowe-cli-extended
-          token:    ${{ secrets.PAT }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+        run: gh workflow run -R awharn-docker/jenkins-nvm-zowe-cli-extended -r master ci.yml


### PR DESCRIPTION
Use GitHub CLI instead of a third party action